### PR TITLE
remove kvdb wal

### DIFF
--- a/components/engine_rocks/src/engine.rs
+++ b/components/engine_rocks/src/engine.rs
@@ -26,6 +26,7 @@ use crate::{RocksEngineIterator, RocksSnapshot};
 pub struct RocksEngine {
     db: Arc<DB>,
     shared_block_cache: bool,
+    disable_wal: bool,
 }
 
 impl RocksEngine {
@@ -33,6 +34,7 @@ impl RocksEngine {
         RocksEngine {
             db,
             shared_block_cache: false,
+            disable_wal: false,
         }
     }
 
@@ -62,6 +64,14 @@ impl RocksEngine {
 
     pub fn set_shared_block_cache(&mut self, enable: bool) {
         self.shared_block_cache = enable;
+    }
+
+    pub fn set_disable_wal(&mut self, disable: bool) {
+        self.disable_wal = disable;
+    }
+
+    pub fn disable_wal(&self) -> bool {
+        self.disable_wal
     }
 }
 

--- a/components/engine_rocks/src/options.rs
+++ b/components/engine_rocks/src/options.rs
@@ -33,6 +33,13 @@ impl RocksWriteOptions {
     pub fn into_raw(self) -> RawWriteOptions {
         self.0
     }
+
+    pub fn disable_wal(&mut self, disable_wal: bool) {
+        if disable_wal {
+            self.0.disable_wal(true);
+            self.0.set_sync(false);
+        }
+    }
 }
 
 impl From<engine_traits::WriteOptions> for RocksWriteOptions {
@@ -40,7 +47,9 @@ impl From<engine_traits::WriteOptions> for RocksWriteOptions {
         let mut r = RawWriteOptions::default();
         r.set_sync(opts.sync());
         r.set_no_slowdown(opts.no_slowdown());
-        RocksWriteOptions(r)
+        let mut o = RocksWriteOptions(r);
+        o.disable_wal(opts.disable_wal());
+        o
     }
 }
 

--- a/components/engine_traits/src/options.rs
+++ b/components/engine_traits/src/options.rs
@@ -33,6 +33,7 @@ impl Default for ReadOptions {
 pub struct WriteOptions {
     sync: bool,
     no_slowdown: bool,
+    disable_wal: bool,
 }
 
 impl WriteOptions {
@@ -40,6 +41,7 @@ impl WriteOptions {
         WriteOptions {
             sync: false,
             no_slowdown: false,
+            disable_wal: false,
         }
     }
 
@@ -58,6 +60,14 @@ impl WriteOptions {
     pub fn no_slowdown(&self) -> bool {
         self.no_slowdown
     }
+
+    pub fn set_disable_wal(&mut self, disable_wal: bool) {
+        self.disable_wal = disable_wal;
+    }
+
+    pub fn disable_wal(&self) -> bool {
+        self.disable_wal
+    }
 }
 
 impl Default for WriteOptions {
@@ -65,6 +75,7 @@ impl Default for WriteOptions {
         WriteOptions {
             sync: false,
             no_slowdown: false,
+            disable_wal: false,
         }
     }
 }

--- a/components/raftstore/src/store/fsm/apply.rs
+++ b/components/raftstore/src/store/fsm/apply.rs
@@ -514,6 +514,7 @@ where
         if !self.kv_wb_mut().is_empty() {
             let mut write_opts = engine_traits::WriteOptions::new();
             write_opts.set_sync(need_sync);
+            // write_opts.set_disable_wal(true);
             self.kv_wb().write_opt(&write_opts).unwrap_or_else(|e| {
                 panic!("failed to write to engine: {:?}", e);
             });

--- a/etc/config-template.toml
+++ b/etc/config-template.toml
@@ -569,6 +569,9 @@
 ## Enable or disable the pipelined write.
 # enable-pipelined-write = true
 
+## Disable kvdb WAL
+# disable_wal = true
+
 ## Allows OS to incrementally sync files to disk while they are being written, asynchronously,
 ## in the background.
 # bytes-per-sync = "1MB"

--- a/src/config.rs
+++ b/src/config.rs
@@ -547,6 +547,7 @@ impl Default for DefaultCfConfig {
                 DBCompressionType::Zstd,
                 DBCompressionType::Zstd,
             ],
+            // TODO(TPC): tune
             write_buffer_size: ReadableSize::mb(128),
             max_write_buffer_number: 5,
             min_write_buffer_number_to_merge: 1,
@@ -967,6 +968,8 @@ pub struct DbConfig {
     pub enable_multi_batch_write: bool,
     #[online_config(skip)]
     pub enable_unordered_write: bool,
+    #[online_config(skip)]
+    pub disable_wal: bool,
     #[online_config(submodule)]
     pub defaultcf: DefaultCfConfig,
     #[online_config(submodule)]
@@ -999,12 +1002,14 @@ impl Default for DbConfig {
             max_open_files: 40960,
             enable_statistics: true,
             stats_dump_period: ReadableDuration::minutes(10),
+            // TODO(TPC): tune
             compaction_readahead_size: ReadableSize::kb(0),
             info_log_max_size: ReadableSize::gb(1),
             info_log_roll_time: ReadableDuration::secs(0),
             info_log_keep_log_file_num: 10,
             info_log_dir: "".to_owned(),
             info_log_level: LogLevel::Info,
+            // TODO(TPC): tune
             rate_bytes_per_sec: ReadableSize::gb(10),
             rate_limiter_refill_period: ReadableDuration::millis(100),
             rate_limiter_mode: DBRateLimiterMode::WriteOnly,
@@ -1014,10 +1019,16 @@ impl Default for DbConfig {
             wal_bytes_per_sync: ReadableSize::kb(512),
             max_sub_compactions: bg_job_limits.max_sub_compactions as u32,
             writable_file_max_buffer_size: ReadableSize::mb(1),
-            use_direct_io_for_flush_and_compaction: false,
+            // TODO(TPC): tune
+            // It should be helpful for pure write workload like rawkv ycsb pure write.
+            use_direct_io_for_flush_and_compaction: true,
+            // TODO(TPC): RocksDB still joins write group when disables WAL. Don't do this if have
+            // time.
             enable_pipelined_write: true,
-            enable_multi_batch_write: true,
+            enable_multi_batch_write: false,
             enable_unordered_write: false,
+            disable_wal: true,
+
             defaultcf: DefaultCfConfig::default(),
             writecf: WriteCfConfig::default(),
             lockcf: LockCfConfig::default(),


### PR DESCRIPTION
1. TiKV 支持重启：stop 的时候会 flush kvdb 所有 cf memtable。
2. rocksdb disableWAL 还是会 join write group，虽然没啥重的操作但可能对 CPU 使用有影响，有时间的话我再改 rocksdb。